### PR TITLE
Move auth user functions into starter repo

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -14,8 +14,8 @@
         org.clojure/tools.logging {:mvn/version "1.3.0"}
         org.slf4j/slf4j-simple {:mvn/version "2.0.13"}
         tick/tick {:mvn/version "1.0"}
-        io.github.jacobobryant/biff.authenticate {:git/sha "36763995e7fe7ebe9ca1d2db1f22d606673c2ffa"}
-        io.github.jacobobryant/biff.sqlite {:git/sha "a3dc2c6922a7b1bafa67ae84bc398c56d2e506c0"}
+        io.github.jacobobryant/biff.authenticate {:git/sha "9ffc5a07f89eafdbc4b1dfb83e26d74375ce0da5"}
+        io.github.jacobobryant/biff.sqlite {:git/sha "fd65ba00263f98476691d52c6465c03386840461"}
         io.github.jacobobryant/biff.fx {:git/sha "9cc18d0d656bdaf2c43247ad29ca4506e3521323"}
         io.github.jacobobryant/biff.graph {:git/sha "8e462c593d8dd90952fd85e05cc3a669454d33ce"}
         io.github.jacobobryant/biff.admin {:git/sha "a5ee135ed339c7b7f7fb0258d1e1d2bf4825294b"}}

--- a/deps.edn
+++ b/deps.edn
@@ -14,8 +14,8 @@
         org.clojure/tools.logging {:mvn/version "1.3.0"}
         org.slf4j/slf4j-simple {:mvn/version "2.0.13"}
         tick/tick {:mvn/version "1.0"}
-        io.github.jacobobryant/biff.authenticate {:git/sha "860e222da3740c8c2b95a58cd09c8f23d95d09ff"}
-        io.github.jacobobryant/biff.sqlite {:git/sha "e82c43d41fc2fdc3f0fb06fc9580c51105117ab2"}
+        io.github.jacobobryant/biff.authenticate {:git/sha "36763995e7fe7ebe9ca1d2db1f22d606673c2ffa"}
+        io.github.jacobobryant/biff.sqlite {:git/sha "a3dc2c6922a7b1bafa67ae84bc398c56d2e506c0"}
         io.github.jacobobryant/biff.fx {:git/sha "9cc18d0d656bdaf2c43247ad29ca4506e3521323"}
         io.github.jacobobryant/biff.graph {:git/sha "8e462c593d8dd90952fd85e05cc3a669454d33ce"}
         io.github.jacobobryant/biff.admin {:git/sha "a5ee135ed339c7b7f7fb0258d1e1d2bf4825294b"}}

--- a/deps.edn
+++ b/deps.edn
@@ -15,7 +15,7 @@
         org.slf4j/slf4j-simple {:mvn/version "2.0.13"}
         tick/tick {:mvn/version "1.0"}
         io.github.jacobobryant/biff.authenticate {:git/sha "9ffc5a07f89eafdbc4b1dfb83e26d74375ce0da5"}
-        io.github.jacobobryant/biff.sqlite {:git/sha "fd65ba00263f98476691d52c6465c03386840461"}
+        io.github.jacobobryant/biff.sqlite {:git/sha "c2b26cdf14cbbe7d0c2c7c65a2cc7f891034f2f5"}
         io.github.jacobobryant/biff.fx {:git/sha "9cc18d0d656bdaf2c43247ad29ca4506e3521323"}
         io.github.jacobobryant/biff.graph {:git/sha "8e462c593d8dd90952fd85e05cc3a669454d33ce"}
         io.github.jacobobryant/biff.admin {:git/sha "a5ee135ed339c7b7f7fb0258d1e1d2bf4825294b"}}

--- a/deps.edn
+++ b/deps.edn
@@ -15,7 +15,7 @@
         org.slf4j/slf4j-simple {:mvn/version "2.0.13"}
         tick/tick {:mvn/version "1.0"}
         io.github.jacobobryant/biff.authenticate {:git/sha "9ffc5a07f89eafdbc4b1dfb83e26d74375ce0da5"}
-        io.github.jacobobryant/biff.sqlite {:git/sha "c2b26cdf14cbbe7d0c2c7c65a2cc7f891034f2f5"}
+        io.github.jacobobryant/biff.sqlite {:git/sha "9059085cecd397ad83ec8f6c5aee81dbb23d9b6b"}
         io.github.jacobobryant/biff.fx {:git/sha "9cc18d0d656bdaf2c43247ad29ca4506e3521323"}
         io.github.jacobobryant/biff.graph {:git/sha "8e462c593d8dd90952fd85e05cc3a669454d33ce"}
         io.github.jacobobryant/biff.admin {:git/sha "a5ee135ed339c7b7f7fb0258d1e1d2bf4825294b"}}

--- a/resources/schema.sql
+++ b/resources/schema.sql
@@ -1,13 +1,10 @@
 -- Auto-generated; do not edit.
 
-CREATE TABLE biff_auth_signin (
-  id BLOB PRIMARY KEY NOT NULL,
-  code TEXT NOT NULL,
-  created_at INT NOT NULL,
-  email TEXT NOT NULL,
-  failed_attempts INT NOT NULL,
-  params TEXT,
-  UNIQUE(email)
+CREATE TABLE biff_sqlite_kv (
+  key_ TEXT NOT NULL,
+  namespace TEXT NOT NULL,
+  value_ BLOB NOT NULL,
+  PRIMARY KEY(namespace, key_)
 ) STRICT;
 
 CREATE TABLE user (

--- a/resources/schema.sql
+++ b/resources/schema.sql
@@ -1,10 +1,11 @@
 -- Auto-generated; do not edit.
 
 CREATE TABLE biff_sqlite_kv (
+  id BLOB PRIMARY KEY NOT NULL,
   key_ TEXT NOT NULL,
   namespace TEXT NOT NULL,
   value_ BLOB NOT NULL,
-  PRIMARY KEY(namespace, key_)
+  UNIQUE(namespace, key_)
 ) STRICT;
 
 CREATE TABLE user (

--- a/src/com/example/app/auth.clj
+++ b/src/com/example/app/auth.clj
@@ -23,7 +23,7 @@
    (merge
     {:biff.auth/app-path "/app"
      :biff.auth/primary-color "#2563eb"
-     :biff.auth/send-email email/send-email
-     :biff.auth/get-user-id get-user-id
-     :biff.auth/create-user! create-user!}
+     :biff/send-email #'email/send-email
+     :biff.auth/get-user-id #'get-user-id
+     :biff.auth/create-user! #'create-user!}
      biff.auth/turnstile-config)))

--- a/src/com/example/app/auth.clj
+++ b/src/com/example/app/auth.clj
@@ -1,12 +1,29 @@
 (ns com.example.app.auth
   (:require [com.biffweb.authenticate :as biff.auth]
-            [com.biffweb.sqlite :as biff.sqlite]
-            [com.example.lib.email :as email]))
+             [com.biffweb.sqlite :as biff.sqlite]
+             [com.example.lib.email :as email]))
+
+(defn get-user-id [ctx email]
+  (:user/id
+   (first
+    (biff.sqlite/execute ctx {:select [:user/id]
+                              :from :user
+                              :where [:= :user/email email]}))))
+
+(defn create-user! [ctx {:keys [email]}]
+  (let [id (random-uuid)]
+    (biff.sqlite/execute ctx {:insert-into :user
+                              :values [{:user/id id
+                                        :user/email email
+                                        :user/joined-at (java.time.Instant/now)}]})
+    id))
 
 (def module
-  (biff.sqlite/auth-module
+  (biff.auth/module
    (merge
     {:biff.auth/app-path "/app"
      :biff.auth/primary-color "#2563eb"
-     :biff.auth/send-email email/send-email}
-    biff.auth/turnstile-config)))
+     :biff.auth/send-email email/send-email
+     :biff.auth/get-user-id get-user-id
+     :biff.auth/create-user! create-user!}
+     biff.auth/turnstile-config)))

--- a/test/com/example/app/auth_test.clj
+++ b/test/com/example/app/auth_test.clj
@@ -1,0 +1,22 @@
+(ns com.example.app.auth-test
+  (:require [clojure.test :refer [deftest is]]
+            [com.biffweb.sqlite :as biff.sqlite]
+            [com.example.app.auth :as auth]
+            [com.example.model.schema :as schema]))
+
+(deftest sqlite-user-functions-roundtrip
+  (let [db-file (java.io.File/createTempFile "starter-auth" ".db")
+        db-path (.getAbsolutePath db-file)]
+    (.delete db-file)
+    (try
+      (let [ctx (biff.sqlite/use-sqlite {:biff/stop []
+                                         :biff.sqlite/db-path db-path
+                                         :biff.sqlite/columns schema/columns})
+            user-id (auth/create-user! ctx {:email "test@example.com" :params {:foo "bar"}})]
+        (is (uuid? user-id))
+        (is (= user-id (auth/get-user-id ctx "test@example.com")))
+        ((first (:biff/stop ctx))))
+      (finally
+        (.delete (java.io.File. db-path))
+        (.delete (java.io.File. (str db-path "-wal")))
+        (.delete (java.io.File. (str db-path "-shm")))))))


### PR DESCRIPTION
AGENT: @jacobobryant this wires the starter app onto the new kv-backed auth flow and moves the user persistence functions into the app.

## What changed
- replaces `biff.sqlite/auth-module` usage with direct `biff.authenticate/module` usage
- implements starter-local `:biff.auth/get-user-id` and `:biff.auth/create-user!`
- pins the starter repo to the companion `biff.sqlite` and `biff.authenticate` branch commits
- adds a round-trip auth persistence test for the starter app

## Context
- Closes #3
- This PR depends on the paired `biff.sqlite` and `biff.authenticate` PRs

## Sprite
- Sign-in page: https://biff-starter-sqlite-c3g4.sprites.app/signin
