### PR TITLE
Extract lifecycle into biff-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,6 @@ clj -M:run soft-deploy
 
 ## Biff-specific pointers
 
-- Modules contribute `:biff.ring/routes`, `:biff.ring/api-routes`, `:biff/init`, schema, and graph resolvers.
+- Modules contribute `:biff.ring/routes`, `:biff.ring/api-routes`, `:biff.core/init`, schema, and graph resolvers.
 - `com.biffweb.ring/module` builds the Ring handler from the active module list.
 - SQLite writes that should enforce ownership rules can go through `:biff.fx.sqlite/authorized-write`.

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources" "target/resources"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
-        io.github.jacobobryant/biff-ring {:git/sha "8d99d611b9eedff9ee448dde233cd21b9191e68c"}
+        io.github.jacobobryant/biff-core {:git/sha "96db6e23f4d3cd50e91d7efad8dc015ac103dce5"}
+        io.github.jacobobryant/biff-ring {:git/sha "5ff68874ed3f08f440b47edec071f3b40b60106e"}
         com.lambdaisland/hiccup {:mvn/version "0.14.67"}
         metosin/malli {:mvn/version "0.16.3"}
         hato/hato {:mvn/version "1.0.0"}
@@ -8,13 +9,14 @@
         io.github.jacobobryant/biff-config {:git/sha "2bac210c9bd52f34d84cab515f2d9a0d19815808"}
         nrepl/nrepl {:mvn/version "1.1.1"}
         org.clojure/tools.logging {:mvn/version "1.3.0"}
+        org.clojure/tools.namespace {:mvn/version "1.5.0"}
         org.slf4j/slf4j-simple {:mvn/version "2.0.13"}
         tick/tick {:mvn/version "1.0"}
         io.github.jacobobryant/biff.authenticate {:git/sha "2fbd39eb20fe48cc915020552e537debb6fa4ede"}
         io.github.jacobobryant/biff.sqlite {:git/sha "9059085cecd397ad83ec8f6c5aee81dbb23d9b6b"}
         io.github.jacobobryant/biff.fx {:git/sha "9cc18d0d656bdaf2c43247ad29ca4506e3521323"}
-        io.github.jacobobryant/biff.graph {:git/sha "824ae1194fc0d2a41118d8c876acd495fb75c9b9"}
-        io.github.jacobobryant/biff.admin {:git/sha "1865ae4168e8a24c250c9b97504c1dfddf600f16"}}
+        io.github.jacobobryant/biff.graph {:git/sha "74be0f60b1e86b34ca7cba3859291695c4d64814"}
+        io.github.jacobobryant/biff.admin {:git/sha "729cb43d77e1105ca2fc44578c70c4d896ba1e3f"}}
  :aliases
  {:prod {:jvm-opts ["-Djdk.attach.allowAttachSelf"
                     "-XX:-OmitStackTraceInFastThrow"

--- a/src/com/example.clj
+++ b/src/com/example.clj
@@ -1,6 +1,8 @@
 (ns com.example
   (:require [clojure.tools.logging :as log]
+            [clojure.tools.namespace.repl :as tn-repl]
             [com.biffweb.admin :as biff.admin]
+            [com.biffweb.core :as biff.core]
             [com.biffweb.config :as config]
             [com.biffweb.sqlite :as biff.sqlite]
             [com.example.authorization :as authz]
@@ -13,24 +15,12 @@
 
 (defonce system (atom {}))
 
-(defn init
-  [modules-var initial-system]
-  (let [init-results
-        (->> @modules-var
-             (keep :biff/init)
-              (map (fn [init-fn] (init-fn modules-var)))
-              (apply merge))]
-     (merge init-results initial-system)))
-
 (defn initial-system []
-  (init
-   #'modules/modules
-    {:biff/stop []
-     :biff/send-email #'email/send-email
-     :biff.sqlite/columns (apply merge (keep :biff.sqlite/columns modules/modules))
-     :biff.sqlite/extra-sql (into [] (mapcat :biff.sqlite/extra-sql) modules/modules)
-     :biff.sqlite/authorize #'authz/authorize
-     :biff.fx/get-handlers (fn [] fx/handlers)}))
+  {:biff/send-email #'email/send-email
+   :biff.sqlite/columns (apply merge (keep :biff.sqlite/columns modules/modules))
+   :biff.sqlite/extra-sql (into [] (mapcat :biff.sqlite/extra-sql) modules/modules)
+   :biff.sqlite/authorize #'authz/authorize
+   :biff.fx/get-handlers (fn [] fx/handlers)})
 
 (def components
    [config/use-aero-config
@@ -39,26 +29,20 @@
     biff.ring/use-jetty])
 
 (defn start []
-  (let [new-system
-         (reduce (fn [ctx component]
-                   (log/info "starting:" (str component))
-                   (component ctx))
-                 (initial-system)
-                 components)]
+  (let [new-system (biff.core/start (initial-system) #'modules/modules components)]
     (reset! system new-system)
     (log/info "System started.")
     (log/info "Go to" (:biff/base-url new-system))
     new-system))
 
 (defn stop []
-  (doseq [stop-fn (reverse (:biff/stop @system))]
-    (stop-fn))
+  (biff.core/stop @system)
   (reset! system {})
   :stopped)
 
 (defn refresh []
   (stop)
-  (start)
+  (tn-repl/refresh :after `start)
   :done)
 
 (defn -main [& _args]


### PR DESCRIPTION
AGENT:

Closes #9.

## Summary
- move the starter lifecycle orchestration into com.biffweb.core/start and com.biffweb.core/stop
- switch module initialization from :biff/init to :biff.core/init
- update com.example/refresh to use tn-repl/refresh :after start
- pin the starter to the companion dependency branches until those changes merge

## Companion PRs
- https://github.com/jacobobryant/biff-core/pull/1
- https://github.com/jacobobryant/biff-ring/pull/2
- https://github.com/jacobobryant/biff.graph/pull/20
- https://github.com/jacobobryant/biff.admin/pull/4

@jacobobryant Live sprite: https://biff-starter-sqlite-c3g4.sprites.app/signin
