### PR TITLE
Adopt biff fx multimethod APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ clj -M:run soft-deploy
 
 - Modules contribute `:biff.ring/routes`, `:biff.ring/api-routes`, `:biff.core/init`, schema, and graph resolvers.
 - `com.biffweb.ring/module` builds the Ring handler from the active module list.
-- SQLite writes that should enforce ownership rules can go through `:biff.fx.sqlite/authorized-write`.
+- SQLite writes that should enforce ownership rules can go through `:biff.sqlite.fx/authorized-write`.

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources" "target/resources"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         io.github.jacobobryant/biff-core {:git/sha "96db6e23f4d3cd50e91d7efad8dc015ac103dce5"}
-        io.github.jacobobryant/biff-ring {:git/sha "5ff68874ed3f08f440b47edec071f3b40b60106e"}
+        io.github.jacobobryant/biff-ring {:git/sha "8e62488d8dd0c357da0efa29a869072ca655544b"}
         com.lambdaisland/hiccup {:mvn/version "0.14.67"}
         metosin/malli {:mvn/version "0.16.3"}
         hato/hato {:mvn/version "1.0.0"}
@@ -13,9 +13,9 @@
         org.slf4j/slf4j-simple {:mvn/version "2.0.13"}
         tick/tick {:mvn/version "1.0"}
         io.github.jacobobryant/biff.authenticate {:git/sha "2fbd39eb20fe48cc915020552e537debb6fa4ede"}
-        io.github.jacobobryant/biff.sqlite {:git/sha "9059085cecd397ad83ec8f6c5aee81dbb23d9b6b"}
-        io.github.jacobobryant/biff.fx {:git/sha "9cc18d0d656bdaf2c43247ad29ca4506e3521323"}
-        io.github.jacobobryant/biff.graph {:git/sha "74be0f60b1e86b34ca7cba3859291695c4d64814"}
+        io.github.jacobobryant/biff.sqlite {:git/sha "3f2baf64c393e00520bec3be63dc327b156c7fbd"}
+        io.github.jacobobryant/biff.fx {:git/sha "ccf1151f6b8363de6e0cc58af95b80ef2763452e"}
+        io.github.jacobobryant/biff.graph {:git/sha "9e363e9c0fe4f8c010e5de29dd3a628d5b49b614"}
         io.github.jacobobryant/biff.admin {:git/sha "729cb43d77e1105ca2fc44578c70c4d896ba1e3f"}}
  :aliases
  {:prod {:jvm-opts ["-Djdk.attach.allowAttachSelf"

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources" "target/resources"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         io.github.jacobobryant/biff-core {:git/sha "96db6e23f4d3cd50e91d7efad8dc015ac103dce5"}
-        io.github.jacobobryant/biff-ring {:git/sha "8e62488d8dd0c357da0efa29a869072ca655544b"}
+        io.github.jacobobryant/biff-ring {:git/sha "6a6063f105e69bd94f37688577e7ed3e02e73abf"}
         com.lambdaisland/hiccup {:mvn/version "0.14.67"}
         metosin/malli {:mvn/version "0.16.3"}
         hato/hato {:mvn/version "1.0.0"}

--- a/src/com/example.clj
+++ b/src/com/example.clj
@@ -6,7 +6,6 @@
             [com.biffweb.config :as config]
             [com.biffweb.sqlite :as biff.sqlite]
             [com.example.authorization :as authz]
-            [com.example.fx :as fx]
             [com.biffweb.ring :as biff.ring]
             [com.example.lib.email :as email]
             [com.example.modules :as modules]
@@ -19,8 +18,7 @@
   {:biff/send-email #'email/send-email
    :biff.sqlite/columns (apply merge (keep :biff.sqlite/columns modules/modules))
    :biff.sqlite/extra-sql (into [] (mapcat :biff.sqlite/extra-sql) modules/modules)
-   :biff.sqlite/authorize #'authz/authorize
-   :biff.fx/get-handlers (fn [] fx/handlers)})
+   :biff.sqlite/authorize #'authz/authorize})
 
 (def components
    [config/use-aero-config

--- a/src/com/example/app/hello.clj
+++ b/src/com/example/app/hello.clj
@@ -1,10 +1,10 @@
 (ns com.example.app.hello
-  (:require [com.biffweb.fx :as fx]
+  (:require [com.biffweb.ring :as biff.ring]
              [com.example.lib.middleware :as mid]
              [com.example.lib.ui :as ui]))
 
-(fx/defroute app-page "/app"
-  [:biff.fx/graph [{:session/user [:user/email]}]]
+(biff.ring/defroute app-page "/app"
+  [:biff.graph.fx/query [{:session/user [:user/email]}]]
   :get
   (fn [_ctx {:keys [session/user]}]
     (ui/page

--- a/src/com/example/app/hello.clj
+++ b/src/com/example/app/hello.clj
@@ -1,9 +1,9 @@
 (ns com.example.app.hello
-  (:require [com.biffweb.ring :as biff.ring]
-             [com.example.lib.middleware :as mid]
-             [com.example.lib.ui :as ui]))
+  (:require [com.biffweb.ring :refer [defroute]]
+            [com.example.lib.middleware :as mid]
+            [com.example.lib.ui :as ui]))
 
-(biff.ring/defroute app-page "/app"
+(defroute app-page "/app"
   [:biff.graph.fx/query [{:session/user [:user/email]}]]
   :get
   (fn [_ctx {:keys [session/user]}]

--- a/src/com/example/fx.clj
+++ b/src/com/example/fx.clj
@@ -1,9 +1,0 @@
-(ns com.example.fx
-  (:require [com.biffweb.sqlite :as biff.sqlite]))
-
-(def handlers
-  {:biff.fx/sqlite biff.sqlite/execute
-   :biff.fx.sqlite/authorized-write biff.sqlite/authorized-write
-   :biff.fx/secure-random-int
-   (fn [_ n]
-     (.nextInt (java.security.SecureRandom.) n))})

--- a/test/com/example/app/hello_test.clj
+++ b/test/com/example/app/hello_test.clj
@@ -6,9 +6,9 @@
   (let [[uri handler-map] hello/app-page
         response ((:get handler-map)
                   {:request-method :get
-                   :biff.fx/handlers
-                   {:biff.fx/graph (fn [_ctx _query]
-                                     {:session/user {:user/email "alice@example.com"}})}})]
+                   :biff.fx/overrides
+                   {:biff.graph.fx/query (fn [_ctx _query]
+                                           {:session/user {:user/email "alice@example.com"}})}})]
     (is (= "/app" uri))
     (is (= 200 (:status response)))
     (is (re-find #"hello world" (:body response)))


### PR DESCRIPTION
AGENT: @jacobobryant This wires the starter into the new fx API: it updates the biff dependency SHAs, removes the local `com.example.fx` namespace, switches `/app` to `biff.ring/defroute`, and uses `:biff.graph.fx/query` plus the new override-based test setup.

Stack:
- jacobobryant/biff.fx#9
- jacobobryant/biff.graph#21
- jacobobryant/biff-ring#3
- jacobobryant/biff.sqlite#23

Sprite URL: https://biff-starter-sqlite-c3g4.sprites.app
Convenience page: https://biff-starter-sqlite-c3g4.sprites.app/signin

Closes #11