### PR TITLE
Add background module support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources" "target/resources"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
          io.github.jacobobryant/biff-core {:git/sha "96db6e23f4d3cd50e91d7efad8dc015ac103dce5"}
-         io.github.jacobobryant/biff-background {:git/sha "b306f758e5e797573cffb36d85877a8fe142beff"}
+         io.github.jacobobryant/biff-background {:git/sha "125b3accf5063a7a2af765dcb47a6ff487827a77"}
          io.github.jacobobryant/biff-ring {:git/sha "6a6063f105e69bd94f37688577e7ed3e02e73abf"}
          com.lambdaisland/hiccup {:mvn/version "0.14.67"}
          metosin/malli {:mvn/version "0.16.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,10 @@
 {:paths ["src" "resources" "target/resources"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
-        io.github.jacobobryant/biff-core {:git/sha "96db6e23f4d3cd50e91d7efad8dc015ac103dce5"}
-        io.github.jacobobryant/biff-ring {:git/sha "6a6063f105e69bd94f37688577e7ed3e02e73abf"}
-        com.lambdaisland/hiccup {:mvn/version "0.14.67"}
-        metosin/malli {:mvn/version "0.16.3"}
+         io.github.jacobobryant/biff-core {:git/sha "96db6e23f4d3cd50e91d7efad8dc015ac103dce5"}
+         io.github.jacobobryant/biff-background {:git/sha "b306f758e5e797573cffb36d85877a8fe142beff"}
+         io.github.jacobobryant/biff-ring {:git/sha "6a6063f105e69bd94f37688577e7ed3e02e73abf"}
+         com.lambdaisland/hiccup {:mvn/version "0.14.67"}
+         metosin/malli {:mvn/version "0.16.3"}
         hato/hato {:mvn/version "1.0.0"}
         cheshire/cheshire {:mvn/version "5.13.0"}
         io.github.jacobobryant/biff-config {:git/sha "2bac210c9bd52f34d84cab515f2d9a0d19815808"}

--- a/src/com/example.clj
+++ b/src/com/example.clj
@@ -1,10 +1,11 @@
 (ns com.example
   (:require [clojure.tools.logging :as log]
-            [clojure.tools.namespace.repl :as tn-repl]
-            [com.biffweb.admin :as biff.admin]
-            [com.biffweb.core :as biff.core]
-            [com.biffweb.config :as config]
-            [com.biffweb.sqlite :as biff.sqlite]
+             [clojure.tools.namespace.repl :as tn-repl]
+             [com.biffweb.admin :as biff.admin]
+             [com.biffweb.background :as biff.background]
+             [com.biffweb.core :as biff.core]
+             [com.biffweb.config :as config]
+             [com.biffweb.sqlite :as biff.sqlite]
             [com.biffweb.ring :as biff.ring]
             [com.example.lib.email :as email]
             [com.example.modules :as modules]
@@ -17,10 +18,12 @@
   {:biff/send-email #'email/send-email})
 
 (def components
-   [config/use-aero-config
-    biff.admin/use-alerts
-    biff.sqlite/use-sqlite
-    biff.ring/use-jetty])
+    [config/use-aero-config
+     biff.admin/use-alerts
+     biff.sqlite/use-sqlite
+     biff.background/use-scheduled-tasks
+     biff.background/use-queues
+     biff.ring/use-jetty])
 
 (defn start []
   (let [new-system (biff.core/start (initial-system) #'modules/modules components)]

--- a/src/com/example/modules.clj
+++ b/src/com/example/modules.clj
@@ -1,5 +1,6 @@
 (ns com.example.modules
   (:require [com.biffweb.admin :as biff.admin]
+            [com.biffweb.background :as biff.background]
             [com.biffweb.ring :as biff.ring]
             [com.biffweb.graph :as biff.graph]
             [com.biffweb.sqlite :as biff.sqlite]
@@ -24,6 +25,7 @@
 
 (def modules
   [(biff.ring/module)
+   (biff.background/module)
    (biff.graph/module)
    model.user/module
    schema/module

--- a/test/com/example/background_test.clj
+++ b/test/com/example/background_test.clj
@@ -1,0 +1,20 @@
+(ns com.example.background-test
+  (:require [clojure.test :refer [deftest is]]
+            [com.biffweb.background :as biff.background]
+            [com.example :as example]
+            [com.example.modules :as modules]))
+
+(deftest app-wires-background-components
+  (is (some #(= biff.background/use-scheduled-tasks %) example/components))
+  (is (some #(= biff.background/use-queues %) example/components)))
+
+(deftest background-module-initializes-empty-config
+  (let [init (some (fn [module]
+                     (when-let [init-fn (:biff.core/init module)]
+                       (let [result (init-fn #'modules/modules)]
+                         (when (contains? result :biff.background/tasks)
+                           result))))
+                   modules/modules)]
+    (is init)
+    (is (= [] (:biff.background/tasks init)))
+    (is (= {} (:biff.background/queues init)))))


### PR DESCRIPTION
AGENT: Fixes #15

## Summary
- add `io.github.jacobobryant/biff-background` pinned to `125b3accf5063a7a2af765dcb47a6ff487827a77`
- register `use-scheduled-tasks`, `use-queues`, and `module` in the starter app without defining any tasks or queues
- add a regression test that verifies the wiring and the empty background config

## Related
- background library PR: https://github.com/jacobobryant/biff-background/pull/1

## Testing
- clojure -M:run test

## App
- @jacobobryant https://biff-starter-sqlite-c3g4.sprites.app
