### PR TITLE
Rename starter keyword wiring for namespaced Biff keys

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources" "target/resources"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
-         io.github.jacobobryant/biff-core {:git/sha "4d0046bfba5b39c1c0ebed39e67aef8de1410859"}
+         io.github.jacobobryant/biff-core {:git/sha "d9630f7024ac0009206fa89dde0f03651fdda5ab"}
          io.github.jacobobryant/biff-background {:git/sha "fd1749df2e59ceb836bd09a24bca4bc980c05bd7"}
          io.github.jacobobryant/biff-ring {:git/sha "3a35c9c1a211174aed692b4934f1995d8cbf8423"}
          com.lambdaisland/hiccup {:mvn/version "0.14.67"}
@@ -14,7 +14,7 @@
         org.slf4j/slf4j-simple {:mvn/version "2.0.13"}
         tick/tick {:mvn/version "1.0"}
         io.github.jacobobryant/biff.authenticate {:git/sha "524f9cd866abb0984550b971ca712b837a2ba129"}
-        io.github.jacobobryant/biff.sqlite {:git/sha "581368f80288ab2035f5f3cbdb52fa718de57567"}
+         io.github.jacobobryant/biff.sqlite {:git/sha "c529e7d4818b4aaf7a6896e3c61f67e869c8db45"}
         io.github.jacobobryant/biff.fx {:git/sha "c44e8988b5d3b6f0839dd36dc5317385c89393a2"}
         io.github.jacobobryant/biff.graph {:git/sha "9e363e9c0fe4f8c010e5de29dd3a628d5b49b614"}
         io.github.jacobobryant/biff.admin {:git/sha "4b365d562ead728e6c11cd2602878871eb33cf5f"}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,23 +1,23 @@
 {:paths ["src" "resources" "target/resources"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
-         io.github.jacobobryant/biff-core {:git/sha "96db6e23f4d3cd50e91d7efad8dc015ac103dce5"}
-         io.github.jacobobryant/biff-background {:git/sha "125b3accf5063a7a2af765dcb47a6ff487827a77"}
-         io.github.jacobobryant/biff-ring {:git/sha "6a6063f105e69bd94f37688577e7ed3e02e73abf"}
+         io.github.jacobobryant/biff-core {:git/sha "4d0046bfba5b39c1c0ebed39e67aef8de1410859"}
+         io.github.jacobobryant/biff-background {:git/sha "fd1749df2e59ceb836bd09a24bca4bc980c05bd7"}
+         io.github.jacobobryant/biff-ring {:git/sha "3a35c9c1a211174aed692b4934f1995d8cbf8423"}
          com.lambdaisland/hiccup {:mvn/version "0.14.67"}
          metosin/malli {:mvn/version "0.16.3"}
         hato/hato {:mvn/version "1.0.0"}
         cheshire/cheshire {:mvn/version "5.13.0"}
-        io.github.jacobobryant/biff-config {:git/sha "2bac210c9bd52f34d84cab515f2d9a0d19815808"}
+        io.github.jacobobryant/biff-config {:git/sha "f7289e16e0a0c257d4bcfaabc18d45251f1bc422"}
         nrepl/nrepl {:mvn/version "1.1.1"}
         org.clojure/tools.logging {:mvn/version "1.3.0"}
         org.clojure/tools.namespace {:mvn/version "1.5.0"}
         org.slf4j/slf4j-simple {:mvn/version "2.0.13"}
         tick/tick {:mvn/version "1.0"}
-        io.github.jacobobryant/biff.authenticate {:git/sha "2fbd39eb20fe48cc915020552e537debb6fa4ede"}
-        io.github.jacobobryant/biff.sqlite {:git/sha "3f2baf64c393e00520bec3be63dc327b156c7fbd"}
-        io.github.jacobobryant/biff.fx {:git/sha "ccf1151f6b8363de6e0cc58af95b80ef2763452e"}
+        io.github.jacobobryant/biff.authenticate {:git/sha "524f9cd866abb0984550b971ca712b837a2ba129"}
+        io.github.jacobobryant/biff.sqlite {:git/sha "581368f80288ab2035f5f3cbdb52fa718de57567"}
+        io.github.jacobobryant/biff.fx {:git/sha "c44e8988b5d3b6f0839dd36dc5317385c89393a2"}
         io.github.jacobobryant/biff.graph {:git/sha "9e363e9c0fe4f8c010e5de29dd3a628d5b49b614"}
-        io.github.jacobobryant/biff.admin {:git/sha "729cb43d77e1105ca2fc44578c70c4d896ba1e3f"}}
+        io.github.jacobobryant/biff.admin {:git/sha "4b365d562ead728e6c11cd2602878871eb33cf5f"}}
  :aliases
  {:prod {:jvm-opts ["-Djdk.attach.allowAttachSelf"
                     "-XX:-OmitStackTraceInFastThrow"

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,11 +1,10 @@
 {:biff.ring/base-url #or [#biff/env BASE_URL "http://localhost:8080"]
- :biff/base-url #ref [:biff.ring/base-url]
  :biff.auth/base-url #ref [:biff.ring/base-url]
  :biff.ring/host #or [#biff/env HOST "localhost"]
  :biff.ring/port #long #or [#biff/env PORT "8080"]
  :biff.sqlite/db-path #or [#biff/env SQLITE_DB_PATH "storage/sqlite/main.db"]
  :biff.nrepl/port #long #or [#biff/env NREPL_PORT "7888"]
- :biff.ring/cookie-secret #biff/env COOKIE_SECRET
+ :biff.ring/cookie-secret #biff/secret COOKIE_SECRET
  :biff.ring/secure #boolean #or [#biff/env SECURE "true"]
  :biff.auth/app-name "Biff Starter App"
 
@@ -23,13 +22,13 @@
  [#ref [:biff.tasks/css-output]
   {:src "config.prod.env" :dest "config.env"}]
 
- :mailersend/api-key #biff/env MAILERSEND_API_KEY
+ :mailersend/api-key #biff/secret MAILERSEND_API_KEY
  :mailersend/from #biff/env MAILERSEND_FROM
  :mailersend/from-name "Biff Starter App"
  :mailersend/reply-to #biff/env MAILERSEND_REPLY_TO
 
  :biff.auth/turnstile-site-key #biff/env TURNSTILE_SITE_KEY
- :biff.auth/turnstile-secret #biff/env TURNSTILE_SECRET_KEY
+ :biff.auth/turnstile-secret #biff/secret TURNSTILE_SECRET_KEY
 
  :biff.admin/user-id #biff/env BIFF_ADMIN_USER_ID
  :biff.admin/alert-email #biff/env BIFF_ADMIN_ALERT_EMAIL}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,9 +1,11 @@
-{:biff/base-url #or [#biff/env BASE_URL "http://localhost:8080"]
+{:biff.ring/base-url #or [#biff/env BASE_URL "http://localhost:8080"]
+ :biff/base-url #ref [:biff.ring/base-url]
+ :biff.auth/base-url #ref [:biff.ring/base-url]
  :biff.ring/host #or [#biff/env HOST "localhost"]
  :biff.ring/port #long #or [#biff/env PORT "8080"]
  :biff.sqlite/db-path #or [#biff/env SQLITE_DB_PATH "storage/sqlite/main.db"]
  :biff.nrepl/port #long #or [#biff/env NREPL_PORT "7888"]
- :biff.ring/cookie-secret #biff/secret COOKIE_SECRET
+ :biff.ring/cookie-secret #biff/env COOKIE_SECRET
  :biff.ring/secure #boolean #or [#biff/env SECURE "true"]
  :biff.auth/app-name "Biff Starter App"
 
@@ -21,13 +23,13 @@
  [#ref [:biff.tasks/css-output]
   {:src "config.prod.env" :dest "config.env"}]
 
- :mailersend/api-key #biff/secret MAILERSEND_API_KEY
+ :mailersend/api-key #biff/env MAILERSEND_API_KEY
  :mailersend/from #biff/env MAILERSEND_FROM
  :mailersend/from-name "Biff Starter App"
  :mailersend/reply-to #biff/env MAILERSEND_REPLY_TO
 
  :biff.auth/turnstile-site-key #biff/env TURNSTILE_SITE_KEY
- :biff.auth/turnstile-secret #biff/secret TURNSTILE_SECRET_KEY
+ :biff.auth/turnstile-secret #biff/env TURNSTILE_SECRET_KEY
 
  :biff.admin/user-id #biff/env BIFF_ADMIN_USER_ID
  :biff.admin/alert-email #biff/env BIFF_ADMIN_ALERT_EMAIL}

--- a/src/com/example.clj
+++ b/src/com/example.clj
@@ -14,22 +14,41 @@
 
 (defonce system (atom {}))
 
+(def secret-keys
+  [:biff.ring/cookie-secret
+   :mailersend/api-key
+   :biff.auth/turnstile-secret])
+
+(defn use-secret-values [ctx]
+  (reduce (fn [ctx k]
+            (update ctx k
+                    (fn [value]
+                      (cond
+                        (nil? value) nil
+                        (fn? value) value
+                        :else (fn [] value)))))
+          ctx
+          secret-keys))
+
 (defn initial-system []
-  {:biff/send-email #'email/send-email})
+  (let [send-email #'email/send-email]
+    {:biff/send-email send-email
+     :biff.auth/send-email send-email
+     :biff.admin/send-email send-email}))
 
 (def components
-    [config/use-aero-config
-     biff.admin/use-alerts
-     biff.sqlite/use-sqlite
-     biff.background/use-scheduled-tasks
-     biff.background/use-queues
-     biff.ring/use-jetty])
+  [config/use-aero-config
+   use-secret-values
+   biff.admin/use-alerts
+   biff.sqlite/use-sqlite
+   biff.background/use-scheduled-tasks
+   biff.background/use-queues
+   biff.ring/use-jetty])
 
 (defn start []
   (let [new-system (biff.core/start (initial-system) #'modules/modules components)]
     (reset! system new-system)
     (log/info "System started.")
-    (log/info "Go to" (:biff/base-url new-system))
     new-system))
 
 (defn stop []

--- a/src/com/example.clj
+++ b/src/com/example.clj
@@ -1,11 +1,11 @@
 (ns com.example
   (:require [clojure.tools.logging :as log]
-             [clojure.tools.namespace.repl :as tn-repl]
-             [com.biffweb.admin :as biff.admin]
-             [com.biffweb.background :as biff.background]
-             [com.biffweb.core :as biff.core]
-             [com.biffweb.config :as config]
-             [com.biffweb.sqlite :as biff.sqlite]
+            [clojure.tools.namespace.repl :as tn-repl]
+            [com.biffweb.admin :as biff.admin]
+            [com.biffweb.background :as biff.background]
+            [com.biffweb.core :as biff.core]
+            [com.biffweb.config :as config]
+            [com.biffweb.sqlite :as biff.sqlite]
             [com.biffweb.ring :as biff.ring]
             [com.example.lib.email :as email]
             [com.example.modules :as modules]
@@ -14,31 +14,13 @@
 
 (defonce system (atom {}))
 
-(def secret-keys
-  [:biff.ring/cookie-secret
-   :mailersend/api-key
-   :biff.auth/turnstile-secret])
-
-(defn use-secret-values [ctx]
-  (reduce (fn [ctx k]
-            (update ctx k
-                    (fn [value]
-                      (cond
-                        (nil? value) nil
-                        (fn? value) value
-                        :else (fn [] value)))))
-          ctx
-          secret-keys))
-
 (defn initial-system []
   (let [send-email #'email/send-email]
-    {:biff/send-email send-email
-     :biff.auth/send-email send-email
+    {:biff.auth/send-email send-email
      :biff.admin/send-email send-email}))
 
 (def components
   [config/use-aero-config
-   use-secret-values
    biff.admin/use-alerts
    biff.sqlite/use-sqlite
    biff.background/use-scheduled-tasks

--- a/src/com/example/app/auth.clj
+++ b/src/com/example/app/auth.clj
@@ -21,11 +21,9 @@
 (def module
   (biff.auth/module
    (merge
-    (let [send-email #'email/send-email]
-      {:biff.auth/app-path "/app"
-       :biff.auth/primary-color "#2563eb"
-       :biff/send-email send-email
-       :biff.auth/send-email send-email
-       :biff.auth/get-user-id #'get-user-id
-       :biff.auth/create-user! #'create-user!})
+    {:biff.auth/app-path "/app"
+     :biff.auth/primary-color "#2563eb"
+     :biff.auth/send-email #'email/send-email
+     :biff.auth/get-user-id #'get-user-id
+     :biff.auth/create-user! #'create-user!}
     biff.auth/turnstile-config)))

--- a/src/com/example/app/auth.clj
+++ b/src/com/example/app/auth.clj
@@ -21,9 +21,11 @@
 (def module
   (biff.auth/module
    (merge
-    {:biff.auth/app-path "/app"
-     :biff.auth/primary-color "#2563eb"
-     :biff/send-email #'email/send-email
-     :biff.auth/get-user-id #'get-user-id
-     :biff.auth/create-user! #'create-user!}
+    (let [send-email #'email/send-email]
+      {:biff.auth/app-path "/app"
+       :biff.auth/primary-color "#2563eb"
+       :biff/send-email send-email
+       :biff.auth/send-email send-email
+       :biff.auth/get-user-id #'get-user-id
+       :biff.auth/create-user! #'create-user!})
     biff.auth/turnstile-config)))

--- a/test/com/example/app/auth_test.clj
+++ b/test/com/example/app/auth_test.clj
@@ -9,13 +9,15 @@
         db-path (.getAbsolutePath db-file)]
     (.delete db-file)
     (try
-      (let [ctx (biff.sqlite/use-sqlite {:biff/stop []
+      (let [ctx (biff.sqlite/use-sqlite {:biff.core/stop []
                                          :biff.sqlite/db-path db-path
                                          :biff.sqlite/columns schema/columns})
-            user-id (auth/create-user! ctx {:email "test@example.com" :params {:foo "bar"}})]
+            user-id (auth/create-user! ctx {:email "test@example.com" :params {:foo "bar"}})
+            stop-fn (or (first (:biff.core/stop ctx))
+                        (first (:biff/stop ctx)))]
         (is (uuid? user-id))
         (is (= user-id (auth/get-user-id ctx "test@example.com")))
-        ((first (:biff/stop ctx))))
+        (stop-fn))
       (finally
         (.delete (java.io.File. db-path))
         (.delete (java.io.File. (str db-path "-wal")))

--- a/test/com/example/app/auth_test.clj
+++ b/test/com/example/app/auth_test.clj
@@ -12,9 +12,8 @@
       (let [ctx (biff.sqlite/use-sqlite {:biff.core/stop []
                                          :biff.sqlite/db-path db-path
                                          :biff.sqlite/columns schema/columns})
-            user-id (auth/create-user! ctx {:email "test@example.com" :params {:foo "bar"}})
-            stop-fn (or (first (:biff.core/stop ctx))
-                        (first (:biff/stop ctx)))]
+             user-id (auth/create-user! ctx {:email "test@example.com" :params {:foo "bar"}})
+            stop-fn (first (:biff.core/stop ctx))]
         (is (uuid? user-id))
         (is (= user-id (auth/get-user-id ctx "test@example.com")))
         (stop-fn))

--- a/test/com/example/background_test.clj
+++ b/test/com/example/background_test.clj
@@ -23,13 +23,5 @@
 (deftest initial-system-uses-namespaced-email-handlers
   (let [send-email #'email/send-email
         system (example/initial-system)]
-    (is (= send-email (:biff/send-email system)))
     (is (= send-email (:biff.auth/send-email system)))
     (is (= send-email (:biff.admin/send-email system)))))
-
-(deftest secret-component-wraps-env-values
-  (let [ctx (example/use-secret-values {:biff.ring/cookie-secret "cookie"
-                                        :mailersend/api-key (fn [] "api")})]
-    (is (= "cookie" ((:biff.ring/cookie-secret ctx))))
-    (is (= "api" ((:mailersend/api-key ctx))))
-    (is (nil? (:biff.auth/turnstile-secret ctx)))))

--- a/test/com/example/background_test.clj
+++ b/test/com/example/background_test.clj
@@ -1,8 +1,9 @@
 (ns com.example.background-test
   (:require [clojure.test :refer [deftest is]]
-            [com.biffweb.background :as biff.background]
-            [com.example :as example]
-            [com.example.modules :as modules]))
+              [com.biffweb.background :as biff.background]
+              [com.example.lib.email :as email]
+              [com.example :as example]
+              [com.example.modules :as modules]))
 
 (deftest app-wires-background-components
   (is (some #(= biff.background/use-scheduled-tasks %) example/components))
@@ -18,3 +19,17 @@
     (is init)
     (is (= [] (:biff.background/tasks init)))
     (is (= {} (:biff.background/queues init)))))
+
+(deftest initial-system-uses-namespaced-email-handlers
+  (let [send-email #'email/send-email
+        system (example/initial-system)]
+    (is (= send-email (:biff/send-email system)))
+    (is (= send-email (:biff.auth/send-email system)))
+    (is (= send-email (:biff.admin/send-email system)))))
+
+(deftest secret-component-wraps-env-values
+  (let [ctx (example/use-secret-values {:biff.ring/cookie-secret "cookie"
+                                        :mailersend/api-key (fn [] "api")})]
+    (is (= "cookie" ((:biff.ring/cookie-secret ctx))))
+    (is (= "api" ((:mailersend/api-key ctx))))
+    (is (nil? (:biff.auth/turnstile-secret ctx)))))


### PR DESCRIPTION
AGENT:

Closes #17.

## What changed
- removed the starter's legacy keyword aliases so it now uses only the namespaced Biff keys
- kept `#biff/secret` in config and moved the secret/stop/base-url/send-email renames into the upstream Biff libraries instead of coercing values locally
- updated the starter dependency SHAs to the matching upstream branches

## Upstream PRs
- jacobobryant/biff-config#2
- jacobobryant/biff.authenticate#9
- jacobobryant/biff.admin#5
- jacobobryant/biff-ring#4
- jacobobryant/biff-core#2
- jacobobryant/biff-background#2
- jacobobryant/biff.fx#10
- jacobobryant/biff.sqlite#24

## Verification
- `clojure -M:run test`
- restarted the `biff-starter-sqlite` sprite service successfully

## Links
- app: https://biff-starter-sqlite-c3g4.sprites.app/
- sign-in page: https://biff-starter-sqlite-c3g4.sprites.app/signin

@jacobobryant
