### PR TITLE
Persist admin pstats with biff.kv

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -17,7 +17,7 @@
          io.github.jacobobryant/biff.sqlite {:git/sha "c529e7d4818b4aaf7a6896e3c61f67e869c8db45"}
         io.github.jacobobryant/biff.fx {:git/sha "c44e8988b5d3b6f0839dd36dc5317385c89393a2"}
         io.github.jacobobryant/biff.graph {:git/sha "9e363e9c0fe4f8c010e5de29dd3a628d5b49b614"}
-        io.github.jacobobryant/biff.admin {:git/sha "4b365d562ead728e6c11cd2602878871eb33cf5f"}}
+         io.github.jacobobryant/biff.admin {:git/sha "0d039c026c353d77ba3b1d16be3e14e5ff5eb0d7"}}
  :aliases
  {:prod {:jvm-opts ["-Djdk.attach.allowAttachSelf"
                     "-XX:-OmitStackTraceInFastThrow"

--- a/test/com/example/background_test.clj
+++ b/test/com/example/background_test.clj
@@ -9,15 +9,17 @@
   (is (some #(= biff.background/use-scheduled-tasks %) example/components))
   (is (some #(= biff.background/use-queues %) example/components)))
 
-(deftest background-module-initializes-empty-config
+(deftest background-module-initializes-admin-pstats-task
   (let [init (some (fn [module]
                      (when-let [init-fn (:biff.core/init module)]
                        (let [result (init-fn #'modules/modules)]
                          (when (contains? result :biff.background/tasks)
-                           result))))
+                            result))))
                    modules/modules)]
     (is init)
-    (is (= [] (:biff.background/tasks init)))
+    (is (= 1 (count (:biff.background/tasks init))))
+    (is (fn? (get-in init [:biff.background/tasks 0 :schedule])))
+    (is (fn? (get-in init [:biff.background/tasks 0 :task])))
     (is (= {} (:biff.background/queues init)))))
 
 (deftest initial-system-uses-namespaced-email-handlers


### PR DESCRIPTION
AGENT: Fixes #19

## Summary
- repin io.github.jacobobryant/biff.admin to 0d039c026c353d77ba3b1d16be3e14e5ff5eb0d7
- persist admin pstats hourly into the biff.admin/pstats kv namespace and merge the last 7 days on the dashboard
- update the starter regression test to assert the admin module contributes the scheduled persistence task

## Related
- biff.admin library PR: https://github.com/jacobobryant/biff.admin/pull/6

## Testing
- clojure -M:run test

## App
- @jacobobryant https://biff-starter-sqlite-c3g4.sprites.app
- Admin: https://biff-starter-sqlite-c3g4.sprites.app/_biff/admin
